### PR TITLE
SLING-6779 - The HTL compiler and Maven Plugin should warn when using potentially invalid options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         The versioning scheme defined here corresponds to SLING-7406 (<module_version>-<htl_specification_version>). Take care when
         releasing to only increase the first part, unless the module provides support for a newer version of the HTL specification.
     -->
-    <version>1.1.3-1.4.0-SNAPSHOT</version>
+    <version>1.2.0-1.4.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Apache Sling Scripting HTL Engine</name>
@@ -103,9 +103,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.11</version>
                 <configuration>
                     <effort>Max</effort>
                     <xmlOutput>true</xmlOutput>
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
-            <version>1.1.3-1.4.0-SNAPSHOT</version>
+            <version>1.2.0-1.4.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -334,13 +334,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>2.25.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-reflect</artifactId>
-            <version>1.6.5</version>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/SightlyEngineConfiguration.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/SightlyEngineConfiguration.java
@@ -21,6 +21,9 @@ package org.apache.sling.scripting.sightly.impl.engine;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -48,11 +51,18 @@ public class SightlyEngineConfiguration {
         )
         boolean keepGenerated() default true;
 
+        @AttributeDefinition(
+                name = "Known Expression Options",
+                description = "A list of extra expression options that should be ignored by the HTL compiler when reporting unknown options."
+        )
+        String[] allowedExpressionOptions();
+
     }
 
     private String engineVersion = "0";
     private boolean keepGenerated;
     private String bundleSymbolicName = "org.apache.sling.scripting.sightly";
+    private Set<String> allowedExpressionOptions;
 
     public String getEngineVersion() {
         return engineVersion;
@@ -68,6 +78,10 @@ public class SightlyEngineConfiguration {
 
     public boolean keepGenerated() {
         return keepGenerated;
+    }
+
+    public Set<String> getAllowedExpressionOptions() {
+        return allowedExpressionOptions;
     }
 
     @Activate
@@ -97,5 +111,6 @@ public class SightlyEngineConfiguration {
             }
         }
         keepGenerated = configuration.keepGenerated();
+        allowedExpressionOptions = new HashSet<>(Arrays.asList(configuration.allowedExpressionOptions()));
     }
 }

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/compiled/SlingHTLMasterCompiler.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/compiled/SlingHTLMasterCompiler.java
@@ -158,6 +158,7 @@ public class SlingHTLMasterCompiler {
                 }
             }
         }
+        sightlyCompiler = SightlyCompiler.withKnownExpressionOptions(sightlyEngineConfiguration.getAllowedExpressionOptions());
     }
 
     /**

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtension.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtension.java
@@ -50,7 +50,6 @@ public class FormatFilterExtension implements RuntimeExtension {
     private static final String FORMAT_OPTION = "format";
     private static final String TYPE_OPTION = "type";
     private static final String LOCALE_OPTION = "locale";
-    private static final String FORMAT_LOCALE_OPTION = "formatLocale";
     private static final String TIMEZONE_OPTION = "timezone";
 
     private static final String DATE_FORMAT_TYPE = "date";
@@ -89,9 +88,6 @@ public class FormatFilterExtension implements RuntimeExtension {
         String localeOption = null;
         if (options.containsKey(LOCALE_OPTION)) {
             localeOption = runtimeObjectModel.toString(options.get(LOCALE_OPTION));
-        }
-        if (localeOption == null && options.containsKey(FORMAT_LOCALE_OPTION)) {
-            localeOption = runtimeObjectModel.toString(options.get(FORMAT_LOCALE_OPTION));
         }
         if (StringUtils.isNotBlank(localeOption)) {
             return LocaleUtils.toLocale(localeOption);

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/SightlyCompiledScriptTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/SightlyCompiledScriptTest.java
@@ -21,9 +21,9 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+
 import javax.script.Bindings;
 import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
 
@@ -37,11 +37,15 @@ import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.osgi.framework.BundleContext;
+import org.powermock.reflect.Whitebox;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class SightlyCompiledScriptTest {


### PR DESCRIPTION
* added all known expression and plugin options to the compiler
* added the possibility to configure the compiler to ignore certain additional options
* enhanced the HTL Script Engine to allow it to configure the compiler for additional options
* enhanced the HTL Maven Plugin to rely on a new configuration option to pass down additional
options to the compiler