### PR TITLE
SLING-8865 - Enhance the HTL runtime and script engine to take advantage of the support for lazy bindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.14.0</version>
+            <version>2.21.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/SightlyBindingsValuesProvider.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/SightlyBindingsValuesProvider.java
@@ -21,7 +21,7 @@ package org.apache.sling.scripting.sightly.impl.engine;
 import javax.script.Bindings;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.scripting.LazyBindings;
 import org.apache.sling.scripting.api.BindingsValuesProvider;
 import org.apache.sling.scripting.sightly.impl.utils.BindingsUtils;
 import org.osgi.service.component.annotations.Component;
@@ -36,14 +36,20 @@ import org.osgi.service.component.annotations.Component;
 )
 public class SightlyBindingsValuesProvider implements BindingsValuesProvider {
 
-    public static final String PROPERTIES = "properties";
+    private static final String PROPERTIES = "properties";
 
     @Override
     public void addBindings(Bindings bindings) {
         if (!bindings.containsKey(PROPERTIES)) {
             Resource currentResource = BindingsUtils.getResource(bindings);
-            if (currentResource != null) {
-                bindings.put(PROPERTIES, currentResource.adaptTo(ValueMap.class));
+            if (bindings instanceof LazyBindings) {
+                if (currentResource != null) {
+                    bindings.put(PROPERTIES, (LazyBindings.Supplier) currentResource::getValueMap);
+                }
+            } else {
+                if (currentResource != null) {
+                    bindings.put(PROPERTIES, currentResource.getValueMap());
+                }
             }
         }
     }

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/utils/BindingsUtils.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/utils/BindingsUtils.java
@@ -22,6 +22,7 @@ import javax.script.SimpleBindings;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.scripting.LazyBindings;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 
@@ -79,7 +80,7 @@ public class BindingsUtils {
      * @return the merging of the two maps
      */
     public static Bindings merge(Bindings former, Bindings latter) {
-        Bindings bindings = new SimpleBindings();
+        Bindings bindings = new LazyBindings();
         bindings.putAll(former);
         bindings.putAll(latter);
         return bindings;


### PR DESCRIPTION
* made `SightlyBindingsValuesProvider` use a `LazyBindings.Supplier` when possible
* switched to `LazyBindings` in `BindingsUtils`