### PR TITLE
SLING-10907 Make compatible with API 2.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.21.0</version>
+            <version>2.23.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
SLING-8742 increased the API version for o.a.s.api.request to 2.5.0. Since the o.a.s.scripting.sightly bundle implements an interface from that package, the module has to be recompiled so that it can work with version 2.24.0.