### PR TITLE
SLING-12471 - The ScriptDependencyResolver can wrongly return null values when invoked concurrently

### DIFF
--- a/src/main/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolver.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolver.java
@@ -128,6 +128,7 @@ public class ScriptDependencyResolver implements ResourceChangeListener, Externa
         try {
             String cacheKey = request.getResource().getResourceType() + ":" + scriptIdentifier;
             Resource result = null;
+            String resourcePath = null;
             if (!resolutionCache.containsKey(cacheKey)) {
                 readLock.unlock();
                 writeLock.lock();
@@ -140,6 +141,8 @@ public class ScriptDependencyResolver implements ResourceChangeListener, Externa
                         } else {
                             resolutionCache.put(cacheKey, NOT_FOUND_MARKER);
                         }
+                    } else {
+                        resourcePath = resolutionCache.get(cacheKey);
                     }
                     readLock.lock();
                 } finally {
@@ -150,6 +153,9 @@ public class ScriptDependencyResolver implements ResourceChangeListener, Externa
                 if (!scriptPath.equals(NOT_FOUND_MARKER)) {
                     result = scriptingResourceResolverProvider.getRequestScopedResourceResolver().getResource(scriptPath);
                 }
+            }
+            if (resourcePath != null && !resourcePath.equals(NOT_FOUND_MARKER)) {
+                result = scriptingResourceResolverProvider.getRequestScopedResourceResolver().getResource(resourcePath);
             }
             return result;
         } finally {

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverConcurrentTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverConcurrentTest.java
@@ -18,11 +18,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package org.apache.sling.scripting.sightly.impl.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import javax.script.Bindings;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,8 +28,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-
-import javax.script.Bindings;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
@@ -50,6 +44,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(Parameterized.class)
@@ -84,7 +84,7 @@ public class ScriptDependencyResolverConcurrentTest {
     }
 
     @Test
-    public void testDependenciesResolvingCacheEnabledConcurren_neverReturnsNull() throws InterruptedException, ExecutionException  {
+    public void testDependenciesResolvingCacheEnabledConcurrent_neverReturnsNull() throws InterruptedException, ExecutionException  {
         SightlyEngineConfiguration configuration = mock(SightlyEngineConfiguration.class);
         when(configuration.getScriptResolutionCacheSize()).thenReturn(1024);
         context.registerService(configuration);

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverConcurrentTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverConcurrentTest.java
@@ -1,0 +1,131 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.scripting.sightly.impl.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.script.Bindings;
+
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.scripting.api.resource.ScriptingResourceResolverProvider;
+import org.apache.sling.scripting.sightly.impl.engine.SightlyEngineConfiguration;
+import org.apache.sling.scripting.sightly.render.RenderContext;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+@RunWith(Parameterized.class)
+public class ScriptDependencyResolverConcurrentTest {
+    
+    @Parameterized.Parameters
+    public static Object[] data() {
+        return new Object[20][0];
+    }
+    
+    
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    @Before
+    public void before() throws PersistenceException {
+        // resource hierarchy
+        ResourceUtil.getOrCreateResource(context.resourceResolver(), "/apps/base/partial.html", "nt:file", "sling:Folder", true);
+        ResourceUtil.getOrCreateResource(context.resourceResolver(), "/apps/inherit/inherit.html", "nt:file", "sling:Folder", true);
+        Resource inherit = context.resourceResolver().getResource("/apps/inherit");
+        assertNotNull(inherit);
+        ModifiableValueMap inheritProperties = inherit.adaptTo(ModifiableValueMap.class);
+        assertNotNull(inheritProperties);
+        inheritProperties.put("sling:resourceSuperType", "base");
+        context.resourceResolver().commit();
+
+        Map<String, Object> testResourceProperties = new HashMap<>();
+        testResourceProperties.put("sling:resourceType", "inherit");
+        ResourceUtil.getOrCreateResource(context.resourceResolver(), "/content/test", testResourceProperties, "sling:Folder", true);
+        context.request().setResource(context.resourceResolver().getResource("/content/test"));
+    }
+
+    @Test
+    public void testDependenciesResolvingCacheEnabledConcurren_neverReturnsNull() throws InterruptedException, ExecutionException  {
+        SightlyEngineConfiguration configuration = mock(SightlyEngineConfiguration.class);
+        when(configuration.getScriptResolutionCacheSize()).thenReturn(1024);
+        context.registerService(configuration);
+
+        ResourceResolver scriptingResolver = spy(context.resourceResolver());
+
+        ScriptingResourceResolverProvider scriptingResourceResolverProvider =
+                mock(ScriptingResourceResolverProvider.class);
+        when(scriptingResourceResolverProvider.getRequestScopedResourceResolver()).thenReturn(scriptingResolver);
+        context.registerService(ScriptingResourceResolverProvider.class, scriptingResourceResolverProvider);
+
+        ScriptDependencyResolver scriptDependencyResolver = spy(context.registerInjectActivateService(new ScriptDependencyResolver()));
+
+        RenderContext renderContext = mock(RenderContext.class);
+        Bindings bindings = mock(Bindings.class);
+        when(renderContext.getBindings()).thenReturn(bindings);
+        when(bindings.get(SlingBindings.REQUEST)).thenReturn(context.request());
+        
+        // invoke resolveScript with the same identifier
+        int size = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(size);
+
+        try {
+            List<Future<Resource>> resolutionValues = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                resolutionValues.add(executor.submit(() -> {
+                    return scriptDependencyResolver.resolveScript(renderContext, "partial.html");
+                }));
+            }
+            int nullValues = 0;
+            for (Future<Resource> v : resolutionValues) {
+                Resource r = v.get();
+                if (r == null) {
+                    nullValues++;
+                }
+            }
+            assertEquals("resolveScript must never return null here",0, nullValues);
+        } finally { 
+            executor.shutdown();
+        }
+
+    }
+
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverTest.java
@@ -19,12 +19,12 @@
 package org.apache.sling.scripting.sightly.impl.utils;
 
 
+import javax.script.Bindings;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.script.Bindings;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;


### PR DESCRIPTION
the first commit contains a failing testcase.