### PR TITLE
SLING-12883 migrate to Sling API 3.x and Jakarta Servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,13 +196,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.i18n</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.api</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -295,7 +295,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         The versioning scheme defined here corresponds to SLING-7406 (<module_version>-<htl_specification_version>). Take care when
         releasing to only increase the first part, unless the module provides support for a newer version of the HTL specification.
     -->
-    <version>1.4.29-1.4.0-SNAPSHOT</version>
+    <version>2.0.0-1.4.0-SNAPSHOT</version>
     <name>Apache Sling Scripting HTL Engine</name>
 
     <description>The Apache Sling Scripting HTL Engine is a Java implementation of the HTML Template Language specification. The bundle contains the
@@ -51,11 +51,12 @@
     </scm>
 
     <properties>
-        <sling.java.version>8</sling.java.version>
+        <sling.java.version>17</sling.java.version>
         <!-- There is significant difference between the locale data provided in JDK8 and starting with JDK9. In order to achieve
         compatibility between newer versions of the JDK and JDK8, we use COMPAT as the default locale data provider for tests. -->
         <java.locale.providers>COMPAT,JRE,SPI</java.locale.providers>
         <project.build.outputTimestamp>2025-04-28T11:56:59Z</project.build.outputTimestamp>
+        <slf4j.version>2.0.17</slf4j.version>
         <surefire.localeProviders>-Djava.locale.providers=${java.locale.providers}</surefire.localeProviders>
         <surefire.argline>${surefire.localeProviders}</surefire.argline>
     </properties>
@@ -149,13 +150,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.25.4</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.api</artifactId>
-            <version>2.1.12</version>
+            <version>2.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -195,13 +196,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.i18n</artifactId>
-            <version>2.6.2</version>
+            <version>3.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.api</artifactId>
-            <version>1.3.8</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -209,6 +210,19 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.wrappers</artifactId>
+            <version>1.1.10</version>
             <scope>provided</scope>
         </dependency>
 
@@ -216,6 +230,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -280,7 +295,19 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-            <version>3.5.4</version>
+            <version>4.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/apache/sling/scripting/sightly/engine/package-info.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/engine/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
-@Version("1.1.0")
+@Version("1.2.0")
 package org.apache.sling.scripting.sightly.engine;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/SightlyCompiledScript.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/SightlyCompiledScript.java
@@ -25,7 +25,7 @@ import javax.script.ScriptEngine;
 
 import java.io.PrintWriter;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.scripting.LazyBindings;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.scripting.sightly.SightlyException;
@@ -48,9 +48,9 @@ public class SightlyCompiledScript extends CompiledScript {
         Bindings bindings = context.getBindings(ScriptContext.ENGINE_SCOPE);
         SlingBindings slingBindings = new SlingBindings();
         slingBindings.putAll(bindings);
-        SlingHttpServletRequest request = slingBindings.getRequest();
+        SlingJakartaHttpServletRequest request = slingBindings.getJakartaRequest();
         if (request == null) {
-            throw new SightlyException("Missing SlingHttpServletRequest from ScriptContext.");
+            throw new SightlyException("Missing SlingJakartaHttpServletRequest from ScriptContext.");
         }
         Object oldBindings = request.getAttribute(SlingBindings.class.getName());
         try {

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/ExtensionUtils.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/ExtensionUtils.java
@@ -30,6 +30,10 @@ import org.apache.sling.scripting.sightly.extension.RuntimeExtension;
  */
 public class ExtensionUtils {
 
+    private ExtensionUtils() {
+        // to hide public ctor
+    }
+
     /**
      * Helper method for checking if the number of arguments passed to a {@link RuntimeExtension} are equal to what the extension requires.
      *

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/ExtensionUtils.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/ExtensionUtils.java
@@ -21,7 +21,7 @@ package org.apache.sling.scripting.sightly.impl.engine.extension;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.scripting.sightly.SightlyException;
 import org.apache.sling.scripting.sightly.extension.RuntimeExtension;
 
@@ -45,15 +45,15 @@ public class ExtensionUtils {
     }
 
     /**
-     * Helper method for setting specific attributes in a {@link SlingHttpServletRequest} scope
+     * Helper method for setting specific attributes in a {@link SlingJakartaHttpServletRequest} scope
      *
-     * @param request              the {@link SlingHttpServletRequest}
+     * @param request              the {@link SlingJakartaHttpServletRequest}
      * @param newRequestAttributes the {@link Map} of attributes to set
      * @return A {@link Map} of original attributes values for substituted keys
      */
     public static Map<String, Object> setRequestAttributes(
-            SlingHttpServletRequest request, Map<String, Object> newRequestAttributes) {
-        Map<String, Object> originalRequestAttributes = new LinkedHashMap<String, Object>();
+            SlingJakartaHttpServletRequest request, Map<String, Object> newRequestAttributes) {
+        Map<String, Object> originalRequestAttributes = new LinkedHashMap<>();
         if (newRequestAttributes != null && request != null) {
             for (Map.Entry<String, Object> attr : newRequestAttributes.entrySet()) {
                 String key = attr.getKey();

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtension.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtension.java
@@ -147,8 +147,8 @@ public class FormatFilterExtension implements RuntimeExtension {
             return TimeZone.getTimeZone(runtimeObjectModel.toString(options.get(TIMEZONE_OPTION)));
         } else {
             Object formatObject = options.get(FORMAT_OPTION);
-            if (formatObject instanceof Calendar) {
-                return ((Calendar) formatObject).getTimeZone();
+            if (formatObject instanceof Calendar calendar) {
+                return calendar.getTimeZone();
             }
             return TimeZone.getDefault();
         }
@@ -156,7 +156,7 @@ public class FormatFilterExtension implements RuntimeExtension {
 
     private Object[] decodeParams(RuntimeObjectModel runtimeObjectModel, Object paramObj) {
         if (paramObj == null) {
-            return null;
+            return null; // NOSONAR
         }
         if (runtimeObjectModel.isCollection(paramObj)) {
             return runtimeObjectModel.toCollection(paramObj).toArray();
@@ -206,8 +206,7 @@ public class FormatFilterExtension implements RuntimeExtension {
 
     private FormatStyle getPredefinedFormattingStyleFromValue(String value) {
         switch (value.toLowerCase(Locale.ROOT)) {
-            case "default":
-            case "medium":
+            case "default", "medium":
                 return FormatStyle.MEDIUM;
             case "short":
                 return FormatStyle.SHORT;

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtension.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtension.java
@@ -67,6 +67,7 @@ public class FormatFilterExtension implements RuntimeExtension {
         ExtensionUtils.checkArgumentCount(RuntimeExtension.FORMAT, arguments, 2);
         RuntimeObjectModel runtimeObjectModel = renderContext.getObjectModel();
         String source = runtimeObjectModel.toString(arguments[0]);
+        @SuppressWarnings("unchecked")
         Map<String, Object> options = (Map<String, Object>) arguments[1];
 
         String formattingType = runtimeObjectModel.toString(options.get(TYPE_OPTION));

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtension.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtension.java
@@ -27,7 +27,7 @@ import java.util.ResourceBundle;
 
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.i18n.ResourceBundleProvider;
 import org.apache.sling.scripting.sightly.extension.RuntimeExtension;
@@ -50,6 +50,7 @@ public class I18nRuntimeExtension implements RuntimeExtension {
         ExtensionUtils.checkArgumentCount(RuntimeExtension.I18N, arguments, 2);
         RuntimeObjectModel runtimeObjectModel = renderContext.getObjectModel();
         String text = runtimeObjectModel.toString(arguments[0]);
+        @SuppressWarnings("unchecked")
         Map<String, Object> options = (Map<String, Object>) arguments[1];
         String locale = runtimeObjectModel.toString(options.get("locale"));
         String hint = runtimeObjectModel.toString(options.get("hint"));
@@ -61,7 +62,7 @@ public class I18nRuntimeExtension implements RuntimeExtension {
     private volatile boolean logged;
 
     private Object getResourceBundleProvider(SlingScriptHelper slingScriptHelper) {
-        Class clazz;
+        Class<?> clazz;
         try {
             clazz = getClass().getClassLoader().loadClass("org.apache.sling.i18n.ResourceBundleProvider");
         } catch (Throwable t) {
@@ -77,7 +78,7 @@ public class I18nRuntimeExtension implements RuntimeExtension {
     private String get(final Bindings bindings, String text, String locale, String basename, String hint) {
 
         final SlingScriptHelper slingScriptHelper = BindingsUtils.getHelper(bindings);
-        final SlingHttpServletRequest request = BindingsUtils.getRequest(bindings);
+        final SlingJakartaHttpServletRequest request = BindingsUtils.getJakartaRequest(bindings);
         final Object resourceBundleProvider = getResourceBundleProvider(slingScriptHelper);
         if (resourceBundleProvider != null) {
             String key = text;

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/PrintWriterJakartaResponseWrapper.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/PrintWriterJakartaResponseWrapper.java
@@ -21,15 +21,13 @@ package org.apache.sling.scripting.sightly.impl.engine.extension;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import org.apache.sling.api.SlingHttpServletResponse;
-import org.apache.sling.api.wrappers.SlingHttpServletResponseWrapper;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
+import org.apache.sling.api.wrappers.SlingJakartaHttpServletResponseWrapper;
 
 /**
  * Wrapper response to redirect the output into a specified print writer
- * @deprecated use {@link PrintWriterJakartaResponseWrapper} instead
  */
-@Deprecated(since = "2.0.0-1.4.0")
-public class PrintWriterResponseWrapper extends SlingHttpServletResponseWrapper {
+public class PrintWriterJakartaResponseWrapper extends SlingJakartaHttpServletResponseWrapper {
 
     private final PrintWriter writer;
 
@@ -39,7 +37,7 @@ public class PrintWriterResponseWrapper extends SlingHttpServletResponseWrapper 
      * @param writer - the base writer
      * @param wrappedResponse - the wrapped response
      */
-    public PrintWriterResponseWrapper(PrintWriter writer, SlingHttpServletResponse wrappedResponse) {
+    public PrintWriterJakartaResponseWrapper(PrintWriter writer, SlingJakartaHttpServletResponse wrappedResponse) {
         super(wrappedResponse);
         this.writer = writer;
     }

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/RenderUnitProvider.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/RenderUnitProvider.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.apache.sling.scripting.core.ScriptNameAwareReader;
@@ -76,7 +76,7 @@ public class RenderUnitProvider implements UseProvider {
         if (identifier.endsWith("." + SightlyScriptEngineFactory.EXTENSION)) {
             Bindings globalBindings = renderContext.getBindings();
             SlingScriptHelper sling = BindingsUtils.getHelper(globalBindings);
-            SlingHttpServletRequest request = BindingsUtils.getRequest(globalBindings);
+            SlingJakartaHttpServletRequest request = BindingsUtils.getJakartaRequest(globalBindings);
             final Resource renderUnitResource = scriptDependencyResolver.resolveScript(renderContext, identifier);
             if (renderUnitResource == null) {
                 // attempt to find a bundled render unit that does not expose a servlet resource via the search paths
@@ -84,7 +84,8 @@ public class RenderUnitProvider implements UseProvider {
                 if (renderUnit != null) {
                     return ProviderOutcome.success(renderUnit);
                 }
-                Resource caller = ResourceResolution.getResourceForRequest(request.getResourceResolver(), request);
+                Resource caller =
+                        ResourceResolution.getResourceForJakartaRequest(request.getResourceResolver(), request);
                 if (caller != null) {
                     String resourceSuperType = caller.getResourceSuperType();
                     StringBuilder errorMessage = new StringBuilder("Cannot find resource ");

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ResourceUseProvider.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ResourceUseProvider.java
@@ -20,7 +20,7 @@ package org.apache.sling.scripting.sightly.impl.engine.extension.use;
 
 import javax.script.Bindings;
 
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.scripting.sightly.impl.utils.BindingsUtils;
@@ -50,7 +50,7 @@ public class ResourceUseProvider implements UseProvider {
     @Override
     public ProviderOutcome provide(String identifier, RenderContext renderContext, Bindings arguments) {
         Bindings globalBindings = renderContext.getBindings();
-        SlingHttpServletRequest request = BindingsUtils.getRequest(globalBindings);
+        SlingJakartaHttpServletRequest request = BindingsUtils.getJakartaRequest(globalBindings);
         String path = normalizePath(request, identifier);
         try {
             Resource resource = request.getResourceResolver().getResource(path);
@@ -63,7 +63,7 @@ public class ResourceUseProvider implements UseProvider {
         return ProviderOutcome.failure();
     }
 
-    private String normalizePath(SlingHttpServletRequest request, String path) {
+    private String normalizePath(SlingJakartaHttpServletRequest request, String path) {
         if (!path.startsWith("/")) {
             path = request.getResource().getPath() + "/" + path;
         }

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ResourceUseProvider.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ResourceUseProvider.java
@@ -44,7 +44,7 @@ public class ResourceUseProvider implements UseProvider {
                 description =
                         "The Service Ranking value acts as the priority with which this Use Provider is queried to return an "
                                 + "Use-object. A higher value represents a higher priority.")
-        int service_ranking() default -10;
+        int service_ranking() default -10; // NOSONAR
     }
 
     @Override

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/UseRuntimeExtension.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/UseRuntimeExtension.java
@@ -59,6 +59,7 @@ public class UseRuntimeExtension implements RuntimeExtension {
         if (StringUtils.isEmpty(identifier)) {
             throw new SightlyException("data-sly-use needs to be passed an identifier");
         }
+        @SuppressWarnings("unchecked")
         Map<String, Object> useArgumentsMap = runtimeObjectModel.toMap(arguments[1]);
         Bindings useArguments = new SimpleBindings(Collections.unmodifiableMap(useArgumentsMap));
         ArrayList<UseProvider> providers = new ArrayList<>(providersMap.values());
@@ -87,6 +88,7 @@ public class UseRuntimeExtension implements RuntimeExtension {
         providersMap.put(serviceReference, provider);
     }
 
+    @SuppressWarnings("unused")
     private void unbindUseProvider(ServiceReference<UseProvider> serviceReference) {
         providersMap.remove(serviceReference);
     }

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/engine/runtime/SlingRuntimeObjectModel.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/engine/runtime/SlingRuntimeObjectModel.java
@@ -42,6 +42,7 @@ public class SlingRuntimeObjectModel extends AbstractRuntimeObjectModel {
         this.legacyToBoolean = legacyToBoolean;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public boolean toBoolean(Object object) {
         if (legacyToBoolean) {
@@ -49,8 +50,7 @@ public class SlingRuntimeObjectModel extends AbstractRuntimeObjectModel {
                 return false;
             }
 
-            if (object instanceof Number) {
-                Number number = (Number) object;
+            if (object instanceof Number number) {
                 return number.doubleValue() != 0.0;
             }
 
@@ -64,12 +64,12 @@ public class SlingRuntimeObjectModel extends AbstractRuntimeObjectModel {
                 return Boolean.parseBoolean(s);
             }
 
-            if (object instanceof Collection) {
-                return !((Collection) object).isEmpty();
+            if (object instanceof Collection collection) {
+                return !collection.isEmpty();
             }
 
-            if (object instanceof Map) {
-                return !((Map) object).isEmpty();
+            if (object instanceof Map map) {
+                return !map.isEmpty();
             }
 
             if (object instanceof Iterable<?>) {
@@ -80,8 +80,8 @@ public class SlingRuntimeObjectModel extends AbstractRuntimeObjectModel {
                 return ((Iterator<?>) object).hasNext();
             }
 
-            if (object instanceof Optional) {
-                return toBoolean(((Optional) object).orElse(false));
+            if (object instanceof Optional optional) {
+                return toBoolean(optional.orElse(false));
             }
 
             if (object.getClass().isArray()) {
@@ -99,8 +99,8 @@ public class SlingRuntimeObjectModel extends AbstractRuntimeObjectModel {
             return null;
         }
         Object result = super.getProperty(target, propertyObj);
-        if (result == null && target instanceof Adaptable) {
-            ValueMap valueMap = ((Adaptable) target).adaptTo(ValueMap.class);
+        if (result == null && target instanceof Adaptable adaptable) {
+            ValueMap valueMap = adaptable.adaptTo(ValueMap.class);
             if (valueMap != null) {
                 String property = toString(propertyObj);
                 result = valueMap.get(property);

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/utils/BindingsUtils.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/utils/BindingsUtils.java
@@ -20,8 +20,8 @@ package org.apache.sling.scripting.sightly.impl.utils;
 
 import javax.script.Bindings;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.LazyBindings;
 import org.apache.sling.api.scripting.SlingBindings;
@@ -31,6 +31,10 @@ import org.apache.sling.api.scripting.SlingScriptHelper;
  * {@code BindingsUtils} provides helper methods for retrieving commonly used objects from a {@link javax.script.Bindings} map.
  */
 public class BindingsUtils {
+
+    private BindingsUtils() {
+        // to hide public ctor
+    }
 
     /**
      * Retrieves the {@link Resource} from a {@link Bindings} map.
@@ -43,23 +47,47 @@ public class BindingsUtils {
     }
 
     /**
-     * Retrieves the {@link SlingHttpServletRequest} from a {@link Bindings} map.
+     * Retrieves the {@link org.apache.sling.api.SlingHttpServletRequest} from a {@link Bindings} map.
      *
      * @param bindings the bindings maps
-     * @return the {@link SlingHttpServletRequest} if found, {@code null} otherwise
+     * @return the {@link org.apache.sling.api.SlingHttpServletRequest} if found, {@code null} otherwise
+     * @deprecated use {@link #getJakartaRequest(Bindings)} instead
      */
-    public static SlingHttpServletRequest getRequest(Bindings bindings) {
-        return (SlingHttpServletRequest) bindings.get(SlingBindings.REQUEST);
+    @Deprecated(since = "2.0.0-1.4.0")
+    public static org.apache.sling.api.SlingHttpServletRequest getRequest(Bindings bindings) {
+        return (org.apache.sling.api.SlingHttpServletRequest) bindings.get(SlingBindings.REQUEST);
     }
 
     /**
-     * Retrieves the {@link SlingHttpServletResponse} from a {@link Bindings} map.
+     * Retrieves the {@link org.apache.sling.api.SlingHttpServletResponse} from a {@link Bindings} map.
      *
      * @param bindings the bindings maps
-     * @return the {@link SlingHttpServletResponse} if found, {@code null} otherwise
+     * @return the {@link org.apache.sling.api.SlingHttpServletResponse} if found, {@code null} otherwise
+     * @deprecated use {@link #getJakartaResponse(Bindings)} instead
      */
-    public static SlingHttpServletResponse getResponse(Bindings bindings) {
-        return (SlingHttpServletResponse) bindings.get(SlingBindings.RESPONSE);
+    @Deprecated(since = "2.0.0-1.4.0")
+    public static org.apache.sling.api.SlingHttpServletResponse getResponse(Bindings bindings) {
+        return (org.apache.sling.api.SlingHttpServletResponse) bindings.get(SlingBindings.RESPONSE);
+    }
+
+    /**
+     * Retrieves the {@link SlingJakartaHttpServletRequest} from a {@link Bindings} map.
+     *
+     * @param bindings the bindings maps
+     * @return the {@link SlingJakartaHttpServletRequest} if found, {@code null} otherwise
+     */
+    public static SlingJakartaHttpServletRequest getJakartaRequest(Bindings bindings) {
+        return (SlingJakartaHttpServletRequest) bindings.get(SlingBindings.JAKARTA_REQUEST);
+    }
+
+    /**
+     * Retrieves the {@link SlingJakartaHttpServletResponse} from a {@link Bindings} map.
+     *
+     * @param bindings the bindings maps
+     * @return the {@link SlingJakartaHttpServletResponse} if found, {@code null} otherwise
+     */
+    public static SlingJakartaHttpServletResponse getJakartaResponse(Bindings bindings) {
+        return (SlingJakartaHttpServletResponse) bindings.get(SlingBindings.JAKARTA_RESPONSE);
     }
 
     /**

--- a/src/main/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolver.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolver.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.observation.ExternalResourceChangeListener;
@@ -117,13 +117,13 @@ public class ScriptDependencyResolver
      * @return the matching resource or null if the looked up resource does not exist
      */
     public Resource resolveScript(RenderContext renderContext, String scriptIdentifier) {
-        SlingHttpServletRequest request = BindingsUtils.getRequest(renderContext.getBindings());
+        SlingJakartaHttpServletRequest jakartaRequest = BindingsUtils.getJakartaRequest(renderContext.getBindings());
         if (!cacheEnabled) {
-            return internalResolveScript(request, renderContext, scriptIdentifier);
+            return internalResolveScript(jakartaRequest, renderContext, scriptIdentifier);
         }
-        String cacheKey = request.getResource().getResourceType() + ":" + scriptIdentifier;
+        String cacheKey = jakartaRequest.getResource().getResourceType() + ":" + scriptIdentifier;
         String scriptPath = resolutionCache.computeIfAbsent(cacheKey, t -> {
-            Resource r = internalResolveScript(request, renderContext, scriptIdentifier);
+            Resource r = internalResolveScript(jakartaRequest, renderContext, scriptIdentifier);
             if (r == null) {
                 return NOT_FOUND_MARKER;
             } else {
@@ -139,8 +139,8 @@ public class ScriptDependencyResolver
     }
 
     private @Nullable Resource internalResolveScript(
-            SlingHttpServletRequest request, RenderContext renderContext, String scriptIdentifier) {
-        Resource caller = ResourceResolution.getResourceForRequest(
+            SlingJakartaHttpServletRequest request, RenderContext renderContext, String scriptIdentifier) {
+        Resource caller = ResourceResolution.getResourceForJakartaRequest(
                 scriptingResourceResolverProvider.getRequestScopedResourceResolver(), request);
         Resource result = ResourceResolution.getResourceFromSearchPath(caller, scriptIdentifier);
         if (result == null) {

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/ExtensionRegistryServiceTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/ExtensionRegistryServiceTest.java
@@ -48,6 +48,8 @@ public class ExtensionRegistryServiceTest {
         ServiceRegistration<RuntimeExtension> registration1 = slingContext
                 .bundleContext()
                 .registerService(RuntimeExtension.class, extension1, new Hashtable<String, Object>() {
+                    private static final long serialVersionUID = 1L;
+
                     {
                         put(RuntimeExtension.NAME, "test");
                     }
@@ -57,6 +59,8 @@ public class ExtensionRegistryServiceTest {
         ServiceRegistration<RuntimeExtension> registration2 = slingContext
                 .bundleContext()
                 .registerService(RuntimeExtension.class, extension2, new Hashtable<String, Object>() {
+                    private static final long serialVersionUID = 1L;
+
                     {
                         put(Constants.SERVICE_RANKING, 2);
                         put(RuntimeExtension.NAME, "test");

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/ResourceResolutionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/ResourceResolutionTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine;
+
+import java.util.Map;
+
+import jakarta.servlet.Servlet;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.scripting.sightly.engine.ResourceResolution;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+/**
+ *
+ */
+public class ResourceResolutionTest {
+
+    @Rule
+    public final SlingContext slingContext = new SlingContext();
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.engine.ResourceResolution#getResourceFromSearchPath(org.apache.sling.api.resource.Resource, java.lang.String)}.
+     */
+    @Test
+    public void testGetResourceFromSearchPath() throws PersistenceException {
+        // both args null
+        assertNull(ResourceResolution.getResourceFromSearchPath(null, null));
+
+        // baseResource not null, path is null
+        ResourceResolver rr = slingContext.resourceResolver();
+        Resource baseResource = rr.resolve("/");
+        assertNull(ResourceResolution.getResourceFromSearchPath(baseResource, null));
+
+        // both args are not null - absolute path to not existing resource
+        String path = "/node1";
+        assertNull(ResourceResolution.getResourceFromSearchPath(baseResource, path));
+
+        // absolute path to existing resource outside of the search path
+        rr.create(rr.getResource("/"), "node1", Map.of());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> ResourceResolution.getResourceFromSearchPath(baseResource, path));
+
+        // absolute path to existing resource within of the search path
+        Resource mockScriptResource = createMockScriptResource(rr);
+        Resource resourceFromSearchPath =
+                ResourceResolution.getResourceFromSearchPath(baseResource, mockScriptResource.getPath());
+        assertNotNull(resourceFromSearchPath);
+        assertSame(resourceFromSearchPath.getPath(), mockScriptResource.getPath());
+
+        // relative path to not existing script resource
+        resourceFromSearchPath = ResourceResolution.getResourceFromSearchPath(baseResource, "sling:invalid");
+        assertNull(resourceFromSearchPath);
+
+        // relative path to not existing script resource
+        resourceFromSearchPath = ResourceResolution.getResourceFromSearchPath(baseResource, "sling:nonexisting");
+        assertEquals(resourceFromSearchPath.getPath(), mockScriptResource.getPath());
+
+        // basePath is nt:file
+        Resource fileResource = rr.create(rr.getResource("/"), "file1", Map.of("jcr:primaryType", "nt:file"));
+        resourceFromSearchPath = ResourceResolution.getResourceFromSearchPath(fileResource, "sling:nonexisting");
+        assertEquals(resourceFromSearchPath.getPath(), mockScriptResource.getPath());
+
+        // basePath adaptable to jakarta servlet
+        Resource mockResource = Mockito.mock(Resource.class);
+        Mockito.when(mockResource.getResourceResolver()).thenReturn(rr);
+        Mockito.when(mockResource.getParent()).thenReturn(baseResource);
+        Servlet mockJakartaServlet = Mockito.mock(Servlet.class);
+        Mockito.when(mockResource.adaptTo(Servlet.class)).thenReturn(mockJakartaServlet);
+        resourceFromSearchPath = ResourceResolution.getResourceFromSearchPath(mockResource, "sling:nonexisting");
+        assertEquals(resourceFromSearchPath.getPath(), mockScriptResource.getPath());
+
+        // basePath adaptable to javax servlet
+        javax.servlet.Servlet mockJavaxServlet = Mockito.mock(javax.servlet.Servlet.class);
+        Mockito.when(mockResource.adaptTo(Servlet.class)).thenReturn(null);
+        Mockito.when(mockResource.adaptTo(javax.servlet.Servlet.class)).thenReturn(mockJavaxServlet);
+        resourceFromSearchPath = ResourceResolution.getResourceFromSearchPath(mockResource, "sling:nonexisting");
+        assertEquals(resourceFromSearchPath.getPath(), mockScriptResource.getPath());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.engine.ResourceResolution#getResourceForRequest(org.apache.sling.api.resource.ResourceResolver, org.apache.sling.api.SlingHttpServletRequest)}.
+     * @deprecated use {@link #testGetResourceForRequestResourceResolverSlingJakartaHttpServletRequest()} instead
+     */
+    @Deprecated(since = "2.0.0")
+    @Test
+    public void testGetResourceForRequestResourceResolverSlingHttpServletRequest() throws PersistenceException {
+        ResourceResolver rr = slingContext.resourceResolver();
+        slingContext.currentResource(rr.resolve("/node1"));
+        org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest request = slingContext.request();
+
+        // handling null params
+        assertNull(ResourceResolution.getResourceForRequest(null, request));
+        assertNull(ResourceResolution.getResourceForRequest(rr, (org.apache.sling.api.SlingHttpServletRequest) null));
+
+        // handing not existing script resource
+        Resource resourceForRequest = ResourceResolution.getResourceForRequest(rr, request);
+        assertNull(resourceForRequest);
+
+        // handing existing script resource
+        Resource scriptResource = createMockScriptResource(rr);
+        resourceForRequest = ResourceResolution.getResourceForRequest(rr, request);
+        assertNotNull(resourceForRequest);
+        assertEquals(resourceForRequest.getPath(), scriptResource.getPath());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.engine.ResourceResolution#getResourceForRequest(org.apache.sling.api.resource.ResourceResolver, org.apache.sling.api.SlingJakartaHttpServletRequest)}.
+     */
+    @Test
+    public void testGetResourceForRequestResourceResolverSlingJakartaHttpServletRequest() throws PersistenceException {
+        ResourceResolver rr = slingContext.resourceResolver();
+        slingContext.currentResource(rr.resolve("/node1"));
+        MockSlingJakartaHttpServletRequest request = slingContext.jakartaRequest();
+
+        // handling null params
+        assertNull(ResourceResolution.getResourceForJakartaRequest(null, request));
+        assertNull(ResourceResolution.getResourceForJakartaRequest(rr, (SlingJakartaHttpServletRequest) null));
+
+        // handing not existing script resource
+        Resource resourceForRequest = ResourceResolution.getResourceForJakartaRequest(rr, request);
+        assertNull(resourceForRequest);
+
+        // handing existing script resource
+        Resource scriptResource = createMockScriptResource(rr);
+        resourceForRequest = ResourceResolution.getResourceForJakartaRequest(rr, request);
+        assertNotNull(resourceForRequest);
+        assertEquals(resourceForRequest.getPath(), scriptResource.getPath());
+
+        // handing existing script resource with empty resource type
+        Resource mockResource = Mockito.mock(Resource.class);
+        Mockito.when(mockResource.getResourceType()).thenReturn("");
+        slingContext.currentResource(mockResource);
+        resourceForRequest = ResourceResolution.getResourceForJakartaRequest(rr, request);
+        assertNull(resourceForRequest);
+    }
+
+    protected @NotNull Resource createMockScriptResource(@NotNull ResourceResolver rr) throws PersistenceException {
+        Resource libResource = rr.create(rr.getResource("/"), "libs", Map.of());
+        return rr.create(libResource, "sling:nonexisting", Map.of());
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/SightlyCompiledScriptTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/SightlyCompiledScriptTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.scripting.sightly.SightlyException;
 import org.apache.sling.scripting.sightly.render.RenderUnit;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
 import org.apache.sling.testing.mock.sling.MockSling;
@@ -44,6 +45,8 @@ import org.osgi.framework.BundleContext;
 import org.powermock.reflect.Whitebox;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -76,6 +79,8 @@ public class SightlyCompiledScriptTest {
         final MockSlingJakartaHttpServletRequest request =
                 spy(new MockSlingJakartaHttpServletRequest(resourceResolver, bundleContext));
         SightlyCompiledScript compiledScript = spy(new SightlyCompiledScript(scriptEngine, renderUnit));
+        assertSame(compiledScript.getEngine(), scriptEngine);
+        assertSame(compiledScript.getRenderUnit(), renderUnit);
         ScriptContext scriptContext = mock(ScriptContext.class);
         StringWriter writer = new StringWriter();
         when(scriptContext.getWriter()).thenReturn(writer);
@@ -119,5 +124,15 @@ public class SightlyCompiledScriptTest {
         for (String key : attributeNameArgumentCaptor.getAllValues()) {
             assertEquals(SlingBindings.class.getName(), key);
         }
+    }
+
+    @Test
+    public void testEvalSlingBindingsWithNullRequest() {
+        SightlyScriptEngine scriptEngine = mock(SightlyScriptEngine.class);
+        final RenderUnit renderUnit = mock(RenderUnit.class);
+        SightlyCompiledScript compiledScript = spy(new SightlyCompiledScript(scriptEngine, renderUnit));
+        ScriptContext scriptContext = mock(ScriptContext.class);
+        when(scriptContext.getBindings(ScriptContext.ENGINE_SCOPE)).thenReturn(new SlingBindings());
+        assertThrows(SightlyException.class, () -> compiledScript.eval(scriptContext));
     }
 }

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/SightlyCompiledScriptTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/SightlyCompiledScriptTest.java
@@ -36,7 +36,7 @@ import org.apache.sling.scripting.sightly.render.RenderUnit;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
 import org.apache.sling.testing.mock.sling.MockSling;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletRequest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -73,8 +73,8 @@ public class SightlyCompiledScriptTest {
                 mock(ExtensionRegistryService.class),
                 new Hashtable<String, Object>());
         ResourceResolver resourceResolver = MockSling.newResourceResolver(bundleContext);
-        final MockSlingHttpServletRequest request =
-                spy(new MockSlingHttpServletRequest(resourceResolver, bundleContext));
+        final MockSlingJakartaHttpServletRequest request =
+                spy(new MockSlingJakartaHttpServletRequest(resourceResolver, bundleContext));
         SightlyCompiledScript compiledScript = spy(new SightlyCompiledScript(scriptEngine, renderUnit));
         ScriptContext scriptContext = mock(ScriptContext.class);
         StringWriter writer = new StringWriter();
@@ -82,7 +82,7 @@ public class SightlyCompiledScriptTest {
         Bindings scriptContextBindings = new SimpleBindings() {
             {
                 put("test", "testValue");
-                put(SlingBindings.REQUEST, request);
+                put(SlingBindings.JAKARTA_REQUEST, request);
                 put(SlingBindings.SLING, mock(SlingScriptHelper.class));
             }
         };
@@ -105,7 +105,8 @@ public class SightlyCompiledScriptTest {
                     assertEquals(oldBindings, bindings);
                     break;
                 case 2:
-                    assertEquals(3, bindings.size());
+                    // NOTE: 4 instead of 3 due to the new additional jarkarta->javax wrapper
+                    assertEquals(4, bindings.size());
                     for (Map.Entry<String, Object> entry : scriptContextBindings.entrySet()) {
                         assertEquals(entry.getValue(), bindings.get(entry.getKey()));
                     }

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/compiled/SlingHTLMasterCompilerTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/compiled/SlingHTLMasterCompilerTest.java
@@ -264,6 +264,8 @@ public class SlingHTLMasterCompilerTest {
     @Test
     public void testGetPOJOFromFQCN() {
         Map<String, String> expectedScriptNames = new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+
             {
                 put("/apps/a_b_c/d_e_f/Pojo.java", JavaEscapeHelper.makeJavaPackage("/apps/a_b_c/d_e_f/Pojo"));
                 put("/apps/a-b-c/d.e.f/Pojo.java", JavaEscapeHelper.makeJavaPackage("/apps/a-b-c/d.e.f/Pojo"));

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/compiled/SourceIdentifierTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/compiled/SourceIdentifierTest.java
@@ -56,6 +56,8 @@ public class SourceIdentifierTest {
     @Test
     public void testPOJOMangling() {
         Map<String, String> expectedMangling = new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+
             {
                 put("/apps/test-static/Pojo.java", "apps.test_static.Pojo");
                 put("/apps/_static/Pojo.java", "apps._static.Pojo");

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/ExtensionUtilsTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/ExtensionUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.sling.scripting.sightly.SightlyException;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletRequest;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class ExtensionUtilsTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.ExtensionUtils#checkArgumentCount(java.lang.String, java.lang.Object[], int)}.
+     */
+    @Test
+    public void testCheckArgumentCount() {
+        ExtensionUtils.checkArgumentCount("test", new Object[0], 0);
+        assertThrows(SightlyException.class, () -> ExtensionUtils.checkArgumentCount("test", new Object[0], 2));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.ExtensionUtils#setRequestAttributes(org.apache.sling.api.SlingJakartaHttpServletRequest, java.util.Map)}.
+     */
+    @Test
+    public void testSetRequestAttributes() {
+        MockSlingJakartaHttpServletRequest jakartaRequest = context.jakartaRequest();
+        jakartaRequest.setAttribute("key1", "value1");
+
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("key1", "newvalue1");
+        attrs.put("key2", null);
+
+        // either param is null does nothing
+        assertTrue(ExtensionUtils.setRequestAttributes(null, null).isEmpty());
+        assertTrue(ExtensionUtils.setRequestAttributes(null, attrs).isEmpty());
+        assertTrue(ExtensionUtils.setRequestAttributes(jakartaRequest, null).isEmpty());
+
+        Map<String, Object> requestAttributes = ExtensionUtils.setRequestAttributes(jakartaRequest, attrs);
+        assertEquals(2, requestAttributes.size());
+        assertEquals("value1", requestAttributes.get("key1"));
+        assertNull(requestAttributes.get("key2"));
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtensionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/FormatFilterExtensionTest.java
@@ -84,6 +84,8 @@ public class FormatFilterExtensionTest {
     @Test
     public void testDateFormatNull() {
         assertNull(subject.call(renderContext, "default", new HashMap<String, Object>() {
+            private static final long serialVersionUID = 1L;
+
             {
                 put(FormatFilterExtension.TYPE_OPTION, "date");
                 put(FormatFilterExtension.FORMAT, null);
@@ -184,6 +186,8 @@ public class FormatFilterExtensionTest {
         assertEquals(
                 "#1: 1918 {0}",
                 subject.call(renderContext, "#1: yyyy {0}", new HashMap<String, Object>() {
+                    private static final long serialVersionUID = 1L;
+
                     {
                         put(FormatFilterExtension.TYPE_OPTION, FormatFilterExtension.DATE_FORMAT_TYPE);
                         put(FormatFilterExtension.FORMAT_OPTION, testDate);
@@ -228,6 +232,8 @@ public class FormatFilterExtensionTest {
     @Test
     public void testStringFormat() {
         Object result = subject.call(renderContext, "This {0} a {1} format", new HashMap<String, Object>() {
+            private static final long serialVersionUID = 1L;
+
             {
                 put(FormatFilterExtension.FORMAT, Arrays.asList("is", "simple"));
                 put(FormatFilterExtension.TYPE_OPTION, FormatFilterExtension.STRING_FORMAT_TYPE);
@@ -249,6 +255,8 @@ public class FormatFilterExtensionTest {
                 renderContext,
                 "This query has {0,plural,zero {# results} one {# result} other {# results}}",
                 new HashMap<String, Object>() {
+                    private static final long serialVersionUID = 1L;
+
                     {
                         put(FormatFilterExtension.FORMAT, Collections.singletonList(7));
                         put(FormatFilterExtension.LOCALE_OPTION, "en_US");

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtensionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtensionTest.java
@@ -102,8 +102,11 @@ public class I18nRuntimeExtensionTest {
                 "invalid1", extension.call(renderContext, "invalid1", Map.of("locale", defaultLocale.toLanguageTag())));
         // with invalid locale
         assertEquals("key1", extension.call(renderContext, "key1", Map.of("locale", "invalid1")));
-        // with basename
-        assertEquals("translatedValue1", extension.call(renderContext, "key1", Map.of("basename", "test.Resource")));
+
+        //  with basename
+        // TODO: figure out why this fails on the ci builds, and resolve the problem
+        // assertEquals("translatedValue1", extension.call(renderContext, "key1", Map.of("basename", "test.Resource")));
+
         // with basename that does not exist
         assertEquals("key1", extension.call(renderContext, "key1", Map.of("basename", "test2.Resource")));
 

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtensionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtensionTest.java
@@ -80,7 +80,7 @@ public class I18nRuntimeExtensionTest {
         assertEquals("key1", extension.call(renderContext, "key1", Map.of("basename", "test.Resource")));
 
         // fill in some values
-        Locale defaultLocale = Locale.getDefault();
+        Locale defaultLocale = context.jakartaRequest().getLocale();
         MockResourceBundle mockRB1 =
                 (MockResourceBundle) context.jakartaRequest().getResourceBundle("test.Resource", defaultLocale);
         mockRB1.put("key1", "translatedValue1");

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtensionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtensionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.i18n.ResourceBundleProvider;
+import org.apache.sling.scripting.sightly.SightlyException;
+import org.apache.sling.scripting.sightly.render.AbstractRuntimeObjectModel;
+import org.apache.sling.scripting.sightly.render.RenderContext;
+import org.apache.sling.scripting.sightly.render.RuntimeObjectModel;
+import org.apache.sling.testing.mock.sling.MockResourceBundle;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ *
+ */
+public class I18nRuntimeExtensionTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    private I18nRuntimeExtension extension;
+    private RenderContext renderContext;
+
+    private SlingBindings requestBindings;
+
+    @Before
+    public void setUp() {
+        extension = context.registerInjectActivateService(I18nRuntimeExtension.class);
+        assertNotNull(extension);
+
+        renderContext = Mockito.mock(RenderContext.class);
+        RuntimeObjectModel runtimeObjModel = new AbstractRuntimeObjectModel() {};
+        Mockito.when(renderContext.getObjectModel()).thenReturn(runtimeObjModel);
+
+        requestBindings = (SlingBindings) context.jakartaRequest().getAttribute(SlingBindings.class.getName());
+        assertNotNull(requestBindings);
+        Mockito.when(renderContext.getBindings()).thenReturn(requestBindings);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.I18nRuntimeExtension#call(org.apache.sling.scripting.sightly.render.RenderContext, java.lang.Object[])}.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCall() {
+        // wrong number or arguments
+        assertThrows(SightlyException.class, () -> extension.call(renderContext));
+
+        // no translation
+        assertEquals("key1", extension.call(renderContext, "key1", Map.of("basename", "test.Resource")));
+
+        // fill in some values
+        Locale defaultLocale = Locale.getDefault();
+        MockResourceBundle mockRB1 =
+                (MockResourceBundle) context.jakartaRequest().getResourceBundle("test.Resource", defaultLocale);
+        mockRB1.put("key1", "translatedValue1");
+        MockResourceBundle mockRB2 =
+                (MockResourceBundle) context.jakartaRequest().getResourceBundle(defaultLocale);
+        mockRB2.put("key1", "translatedValue2");
+        mockRB2.put("key1 ((myhint1))", "translatedHint2");
+
+        // has translation
+        assertEquals("translatedValue2", extension.call(renderContext, "key1", Map.of()));
+        // with hint
+        assertEquals("translatedHint2", extension.call(renderContext, "key1", Map.of("hint", "myhint1")));
+        // with valid locale
+        assertEquals(
+                "translatedValue2",
+                extension.call(renderContext, "key1", Map.of("locale", defaultLocale.toLanguageTag())));
+        // with valid locale and no matching key
+        assertEquals(
+                "invalid1", extension.call(renderContext, "invalid1", Map.of("locale", defaultLocale.toLanguageTag())));
+        // with invalid locale
+        assertEquals("key1", extension.call(renderContext, "key1", Map.of("locale", "invalid1")));
+        // with basename
+        assertEquals("translatedValue1", extension.call(renderContext, "key1", Map.of("basename", "test.Resource")));
+        // with basename that does not exist
+        assertEquals("key1", extension.call(renderContext, "key1", Map.of("basename", "test2.Resource")));
+
+        // with null resourceBundleProvider
+        requestBindings = Mockito.spy(requestBindings);
+        Mockito.when(renderContext.getBindings()).thenReturn(requestBindings);
+        SlingScriptHelper mockScriptHelper = Mockito.mock(SlingScriptHelper.class);
+        Mockito.when(mockScriptHelper.getService(any(Class.class))).thenReturn(null);
+        Mockito.when(requestBindings.get(SlingBindings.SLING)).thenReturn(mockScriptHelper);
+        assertEquals("key1", extension.call(renderContext, "key1", Map.of()));
+
+        // with null resourceBundle
+        ResourceBundleProvider mockRBP = Mockito.mock(ResourceBundleProvider.class);
+        Mockito.when(mockScriptHelper.getService(any(Class.class))).thenReturn(mockRBP);
+        assertEquals("key1", extension.call(renderContext, "key1", Map.of()));
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtensionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/I18nRuntimeExtensionTest.java
@@ -104,8 +104,7 @@ public class I18nRuntimeExtensionTest {
         assertEquals("key1", extension.call(renderContext, "key1", Map.of("locale", "invalid1")));
 
         //  with basename
-        // TODO: figure out why this fails on the ci builds, and resolve the problem
-        // assertEquals("translatedValue1", extension.call(renderContext, "key1", Map.of("basename", "test.Resource")));
+        assertEquals("translatedValue1", extension.call(renderContext, "key1", Map.of("basename", "test.Resource")));
 
         // with basename that does not exist
         assertEquals("key1", extension.call(renderContext, "key1", Map.of("basename", "test2.Resource")));

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/IncludeRuntimeExtensionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/IncludeRuntimeExtensionTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.api.servlets.ServletResolver;
+import org.apache.sling.scripting.sightly.SightlyException;
+import org.apache.sling.scripting.sightly.render.AbstractRuntimeObjectModel;
+import org.apache.sling.scripting.sightly.render.RenderContext;
+import org.apache.sling.scripting.sightly.render.RuntimeObjectModel;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+/**
+ *
+ */
+public class IncludeRuntimeExtensionTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    private IncludeRuntimeExtension extension;
+    private RenderContext renderContext;
+    private SlingBindings requestBindings;
+
+    private SlingScriptHelper mockScriptHelper;
+
+    @Before
+    public void setUp() throws PersistenceException {
+        extension = context.registerInjectActivateService(IncludeRuntimeExtension.class);
+        assertNotNull(extension);
+
+        renderContext = Mockito.mock(RenderContext.class);
+        RuntimeObjectModel runtimeObjModel = new AbstractRuntimeObjectModel() {};
+        Mockito.when(renderContext.getObjectModel()).thenReturn(runtimeObjModel);
+
+        requestBindings = (SlingBindings) context.jakartaRequest().getAttribute(SlingBindings.class.getName());
+        assertNotNull(requestBindings);
+
+        requestBindings = Mockito.spy(requestBindings);
+        mockScriptHelper = Mockito.mock(SlingScriptHelper.class);
+        Mockito.when(requestBindings.get(SlingBindings.SLING)).thenReturn(mockScriptHelper);
+        Mockito.when(renderContext.getBindings()).thenReturn(requestBindings);
+
+        ResourceResolver rr = context.resourceResolver();
+        context.currentResource(rr.create(rr.getResource("/"), "node1", Map.of()));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.IncludeRuntimeExtension#call(org.apache.sling.scripting.sightly.render.RenderContext, java.lang.Object[])}.
+     */
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCall() throws ServletException, IOException, javax.servlet.ServletException {
+        // wrong number or arguments
+        assertThrows(SightlyException.class, () -> extension.call(renderContext));
+
+        Map<String, Object> arguments = new HashMap<>();
+        // Sling ServletResolver service is unavailable
+        assertThrows(SightlyException.class, () -> extension.call(renderContext, "page.html", arguments));
+
+        ServletResolver mockServletResolver = Mockito.mock(ServletResolver.class);
+        Mockito.when(mockScriptHelper.getService(ServletResolver.class)).thenReturn(mockServletResolver);
+
+        // empty script
+        assertThrows(SightlyException.class, () -> extension.call(renderContext, "", arguments));
+
+        // Failed to locate script
+        assertThrows(SightlyException.class, () -> extension.call(renderContext, "page.html", arguments));
+
+        // jakarta Servlet resource
+        Servlet mockJakartaServlet = Mockito.mock(Servlet.class);
+        Mockito.doAnswer(invocation -> {
+                    invocation.getArgument(1, ServletResponse.class).getWriter().print("hello");
+                    return null;
+                })
+                .when(mockJakartaServlet)
+                .service(any(ServletRequest.class), any(ServletResponse.class));
+        Mockito.when(mockServletResolver.resolve(any(Resource.class), eq("page.html")))
+                .thenReturn(mockJakartaServlet);
+        Object result = extension.call(renderContext, "page.html", arguments);
+        assertEquals("hello", result);
+
+        // jakarta Servlet throws exception during service
+        Mockito.doThrow(ServletException.class)
+                .when(mockJakartaServlet)
+                .service(any(ServletRequest.class), any(ServletResponse.class));
+        assertThrows(SightlyException.class, () -> extension.call(renderContext, "page.html", arguments));
+
+        // javax Servlet resource
+        javax.servlet.Servlet mockJavaxServlet = Mockito.mock(javax.servlet.Servlet.class);
+        Mockito.doAnswer(invocation -> {
+                    invocation
+                            .getArgument(1, javax.servlet.ServletResponse.class)
+                            .getWriter()
+                            .print("hello2");
+                    return null;
+                })
+                .when(mockJavaxServlet)
+                .service(any(javax.servlet.ServletRequest.class), any(javax.servlet.ServletResponse.class));
+        Mockito.when(mockServletResolver.resolveServlet(any(Resource.class), eq("page2.html")))
+                .thenReturn(mockJavaxServlet);
+        result = extension.call(renderContext, "page2.html", arguments);
+        assertEquals("hello2", result);
+
+        // javax Servlet throws exception during service
+        Mockito.doThrow(javax.servlet.ServletException.class)
+                .when(mockJavaxServlet)
+                .service(any(javax.servlet.ServletRequest.class), any(javax.servlet.ServletResponse.class));
+        assertThrows(SightlyException.class, () -> extension.call(renderContext, "page2.html", arguments));
+
+        // with prepend / append path arguments
+        Mockito.doAnswer(invocation -> {
+                    invocation.getArgument(1, ServletResponse.class).getWriter().print("hello3");
+                    return null;
+                })
+                .when(mockJakartaServlet)
+                .service(any(ServletRequest.class), any(ServletResponse.class));
+        Mockito.when(mockServletResolver.resolve(any(Resource.class), eq("prepend1/page3.html/append1")))
+                .thenReturn(mockJakartaServlet);
+        arguments.put("prependPath", "prepend1");
+        arguments.put("appendPath", "append1");
+        result = extension.call(renderContext, "page3.html", arguments);
+        assertEquals("hello3", result);
+
+        // path with leading + trailing slashes
+        result = extension.call(renderContext, "/page3.html/", arguments);
+        assertEquals("hello3", result);
+
+        // args with leading + trailing slashes
+        arguments.put("prependPath", "prepend1/");
+        arguments.put("appendPath", "/append1");
+        result = extension.call(renderContext, "page3.html", arguments);
+        assertEquals("hello3", result);
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/PrintWriterJakartaResponseWrapperTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/PrintWriterJakartaResponseWrapperTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletResponse;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+
+/**
+ *
+ */
+public class PrintWriterJakartaResponseWrapperTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.PrintWriterJakartaResponseWrapper#getWriter()}.
+     */
+    @Test
+    public void testGetWriter() throws IOException {
+        MockSlingJakartaHttpServletResponse jakartaResponse = context.jakartaResponse();
+        PrintWriter pw = new PrintWriter(jakartaResponse.getOutputStream());
+        PrintWriterJakartaResponseWrapper wrapper = new PrintWriterJakartaResponseWrapper(pw, jakartaResponse);
+        assertSame(wrapper.getWriter(), pw);
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/PrintWriterResponseWrapperTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/PrintWriterResponseWrapperTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+
+/**
+ * @deprecated use {@link PrintWriterJakartaResponseWrapperTest} instead
+ */
+@Deprecated(since = "2.0.0-1.4.0")
+public class PrintWriterResponseWrapperTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.PrintWriterResponseWrapper#getWriter()}.
+     */
+    @Test
+    public void testGetWriter() throws IOException {
+        MockSlingHttpServletResponse response = context.response();
+        PrintWriter pw = new PrintWriter(response.getOutputStream());
+        PrintWriterResponseWrapper wrapper = new PrintWriterResponseWrapper(pw, response);
+        assertSame(wrapper.getWriter(), pw);
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/ResourceRuntimeExtensionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/ResourceRuntimeExtensionTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.scripting.sightly.SightlyException;
+import org.apache.sling.scripting.sightly.render.AbstractRuntimeObjectModel;
+import org.apache.sling.scripting.sightly.render.RenderContext;
+import org.apache.sling.scripting.sightly.render.RuntimeObjectModel;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockJakartaRequestDispatcherFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ *
+ */
+public class ResourceRuntimeExtensionTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    private ResourceRuntimeExtension extension;
+    private RenderContext renderContext;
+    private SlingBindings requestBindings;
+
+    @Before
+    public void setUp() throws PersistenceException {
+        extension = context.registerInjectActivateService(ResourceRuntimeExtension.class);
+        assertNotNull(extension);
+
+        renderContext = Mockito.mock(RenderContext.class);
+        RuntimeObjectModel runtimeObjModel = new AbstractRuntimeObjectModel() {};
+        Mockito.when(renderContext.getObjectModel()).thenReturn(runtimeObjModel);
+
+        requestBindings = (SlingBindings) context.jakartaRequest().getAttribute(SlingBindings.class.getName());
+        assertNotNull(requestBindings);
+        Mockito.when(renderContext.getBindings()).thenReturn(requestBindings);
+
+        ResourceResolver rr = context.resourceResolver();
+        context.currentResource(rr.create(rr.getResource("/"), "node1", Map.of()));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.ResourceRuntimeExtension#call(org.apache.sling.scripting.sightly.render.RenderContext, java.lang.Object[])}.
+     */
+    @Test
+    public void testCall() throws ServletException, IOException {
+        // wrong number or arguments
+        assertThrows(SightlyException.class, () -> extension.call(renderContext));
+
+        // mock the request dispatcher
+        MockJakartaRequestDispatcherFactory mockDispatchFactory =
+                Mockito.mock(MockJakartaRequestDispatcherFactory.class);
+        context.jakartaRequest().setRequestDispatcherFactory(mockDispatchFactory);
+
+        Map<String, Object> arguments = new HashMap<>();
+        // null RequestDispatcher
+        assertThrows(SightlyException.class, () -> extension.call(renderContext, "page.html", arguments));
+
+        // not null RequestDispatcher with string path
+        RequestDispatcher mockPageRequestDispatcher = Mockito.mock(RequestDispatcher.class);
+        Mockito.doAnswer(invocation -> {
+                    invocation.getArgument(1, ServletResponse.class).getWriter().print("hello");
+                    return null;
+                })
+                .when(mockPageRequestDispatcher)
+                .include(any(ServletRequest.class), any(ServletResponse.class));
+        Mockito.when(mockDispatchFactory.getRequestDispatcher(any(Resource.class), any(RequestDispatcherOptions.class)))
+                .thenReturn(mockPageRequestDispatcher);
+        Object result = extension.call(renderContext, "page.html", arguments);
+        assertEquals("hello", result);
+
+        // with Resource path
+        Resource pageResource = context.resourceResolver().resolve("/node1/page.html");
+        result = extension.call(renderContext, pageResource, arguments);
+        assertEquals("hello", result);
+
+        // with includePath that resolves to null, should skip include the resource itself
+        //   due to RecursionTooDeepException guard
+        result = extension.call(renderContext, "../..", arguments);
+        assertEquals("", result);
+        // same with resourceType that is not different from current resource
+        arguments.put("resourceType", "nt:unstructured");
+        result = extension.call(renderContext, "../..", arguments);
+        assertEquals("", result);
+
+        // with includePath that resolves to null, should include the resource itself
+        //   with the different selectors
+        arguments.clear();
+        arguments.put("addSelectors", "tidy");
+        result = extension.call(renderContext, "../..", arguments);
+        assertEquals("hello", result);
+        //  should include the resource itself with the different resourceType
+        arguments.remove("addSelectors");
+        arguments.put("resourceType", "nt:folder");
+        result = extension.call(renderContext, "../..", arguments);
+        assertEquals("hello", result);
+
+        // with includedResource that resolves to a resource
+        result = extension.call(renderContext, "/node1", arguments);
+        assertEquals("hello", result);
+
+        // with various options
+        arguments.put("resourceType", "nt:folder");
+        arguments.put("path", "page");
+        arguments.put("prependPath", "/node1/");
+        arguments.put("appendPath", "/child.selector0.html");
+        arguments.put("selectors", "selector1.selector2");
+        arguments.put("removeSelectors", "selector1");
+        arguments.put("addSelectors", "selector3");
+        arguments.put("requestAttributes", Map.of("attr1", "value1"));
+        result = extension.call(renderContext, "", arguments);
+        assertEquals("hello", result);
+
+        // same with alternate argument types
+        arguments.put("prependPath", "node1");
+        arguments.put("appendPath", "child.html");
+        arguments.put("removeSelectors", new String[] {"selector1", ""});
+        arguments.put("addSelectors", new String[] {"selector3", ""});
+        result = extension.call(renderContext, "", arguments);
+        assertEquals("hello", result);
+
+        // same with alternate argument type #2
+        arguments.put("removeSelectors", new Object());
+        arguments.put("addSelectors", new Object());
+        result = extension.call(renderContext, "", arguments);
+        assertEquals("hello", result);
+
+        // same with alternate argument type #3
+        arguments.put("prependPath", null);
+        arguments.put("appendPath", null);
+        arguments.put("removeSelectors", null);
+        arguments.put("addSelectors", null);
+        arguments.put("resourceType", "");
+        result = extension.call(renderContext, "", arguments);
+        assertEquals("hello", result);
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/URIManipulationFilterExtensionTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/URIManipulationFilterExtensionTest.java
@@ -94,6 +94,8 @@ public class URIManipulationFilterExtensionTest {
         assertEquals(
                 "/example/search.html?q=6%25-10%25",
                 underTest.call(renderContext, "/example/search?q=6%25-10%25", new LinkedHashMap<String, Object>() {
+                    private static final long serialVersionUID = 1L;
+
                     {
                         put(URIManipulationFilterExtension.EXTENSION, "html");
                     }
@@ -101,10 +103,14 @@ public class URIManipulationFilterExtensionTest {
         assertEquals(
                 "/example/search.a.html?q=6%25-10%25&s=%40sling&t=%25sling",
                 underTest.call(renderContext, "/example/search?q=6%25-10%25", new LinkedHashMap<String, Object>() {
+                    private static final long serialVersionUID = 1L;
+
                     {
                         put(URIManipulationFilterExtension.EXTENSION, "html");
                         put(URIManipulationFilterExtension.ADD_SELECTORS, "a");
                         put(URIManipulationFilterExtension.ADD_QUERY, new LinkedHashMap<String, Object>() {
+                            private static final long serialVersionUID = 1L;
+
                             {
                                 put("s", "@sling");
                                 put("t", "%sling");
@@ -120,6 +126,8 @@ public class URIManipulationFilterExtensionTest {
         assertEquals(
                 "mailto:test@apache.org",
                 underTest.call(renderContext, "mailto:test@apache.org", new LinkedHashMap<String, Object>() {
+                    private static final long serialVersionUID = 1L;
+
                     {
                         put(URIManipulationFilterExtension.EXTENSION, "html");
                     }
@@ -136,6 +144,8 @@ public class URIManipulationFilterExtensionTest {
                 + "hhx4dbgYKAAA7";
 
         assertEquals(dataUrl, underTest.call(renderContext, dataUrl, new LinkedHashMap<String, Object>() {
+            private static final long serialVersionUID = 1L;
+
             {
                 put(URIManipulationFilterExtension.EXTENSION, "html");
             }

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/JavaUseProviderTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/JavaUseProviderTest.java
@@ -87,7 +87,6 @@ public class JavaUseProviderTest {
         assertNotNull(provider);
 
         arguments = new SlingBindings();
-        assertNotNull(arguments);
         // for coverage of request attribute juggling before and after provide
         arguments.put("key1", "value1");
         arguments.put("key2", "value2");

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/JavaUseProviderTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/JavaUseProviderTest.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use;
+
+import javax.script.Bindings;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.adapter.Adaptable;
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.scripting.sightly.impl.engine.bundled.BundledUnitManagerImpl;
+import org.apache.sling.scripting.sightly.impl.engine.compiled.SlingHTLMasterCompiler;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.AbstractModel;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.EnumModel;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.InterfaceModel;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.MockRenderUnit;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.OtherModel;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.PojoModel;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.PojoUseModel;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.ResourceModel;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.ResourceModel2;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.SlingHttpServletRequestModel;
+import org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels.SlingJakartaHttpServletRequestModel;
+import org.apache.sling.scripting.sightly.render.RenderContext;
+import org.apache.sling.scripting.sightly.render.RenderUnit;
+import org.apache.sling.scripting.sightly.use.ProviderOutcome;
+import org.apache.sling.testing.mock.osgi.MockBundle;
+import org.apache.sling.testing.mock.osgi.MockOsgi;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.BundleEvent;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+/**
+ *
+ */
+public class JavaUseProviderTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    private JavaUseProvider provider;
+    private SlingBindings arguments;
+
+    private RenderContext renderContext;
+
+    private SlingBindings requestBindings;
+
+    private BundledUnitManagerImpl mockBundledUnitManager;
+
+    @Before
+    public void setUp() throws PersistenceException {
+        mockBundledUnitManager =
+                context.registerService(BundledUnitManagerImpl.class, Mockito.mock(BundledUnitManagerImpl.class));
+        Mockito.when(mockBundledUnitManager.getBundledRenderUnitClassloader(any(Bindings.class)))
+                .thenReturn(getClass().getClassLoader());
+        provider = context.registerInjectActivateService(JavaUseProvider.class);
+        assertNotNull(provider);
+
+        arguments = new SlingBindings();
+        assertNotNull(arguments);
+        // for coverage of request attribute juggling before and after provide
+        arguments.put("key1", "value1");
+        arguments.put("key2", "value2");
+        context.jakartaRequest().setAttribute("key1", "requestValue1");
+
+        ResourceResolver rr = context.resourceResolver();
+        context.currentResource(rr.create(rr.getResource("/"), "node1", Map.of()));
+
+        renderContext = Mockito.mock(RenderContext.class);
+        requestBindings = (SlingBindings) context.jakartaRequest().getAttribute(SlingBindings.class.getName());
+        assertNotNull(requestBindings);
+        Mockito.when(renderContext.getBindings()).thenReturn(requestBindings);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.use.JavaUseProvider#provide(java.lang.String, org.apache.sling.scripting.sightly.render.RenderContext, javax.script.Bindings)}.
+     */
+    @Test
+    public void testProvideWithInvalidClassName() {
+        ProviderOutcome outcome = provider.provide("Not Valid", renderContext, arguments);
+        assertTrue(outcome.isFailure());
+    }
+
+    @Test
+    public void testProvideWithNullBundledRenderUnitClassLoader() {
+        Mockito.when(mockBundledUnitManager.getBundledRenderUnitClassloader(any(Bindings.class)))
+                .thenReturn(null);
+
+        ProviderOutcome outcome =
+                provider.provide(SlingJakartaHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+    }
+
+    @Test
+    public void testProvideWithCaughtException() {
+        Mockito.when(mockBundledUnitManager.getBundledRenderUnitClassloader(any(Bindings.class)))
+                .thenThrow(RuntimeException.class);
+
+        ProviderOutcome outcome =
+                provider.provide(SlingJakartaHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+    }
+
+    @Test
+    public void testProvideForBundleHeaderDeclaredSlingModel() {
+        simulateBundleStartedWithSlingModelClasses();
+
+        // sling model with javax servlet adaptable
+        ProviderOutcome outcome =
+                provider.provide(SlingHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // sling model with jakarta servlet adaptable
+        outcome = provider.provide(SlingJakartaHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // sling model with resource adaptable
+        outcome = provider.provide(ResourceModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // sling model that throws exception should fail
+        outcome = provider.provide(ResourceModel2.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+
+        // sling model with other adaptable should fail
+        outcome = provider.provide(OtherModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+
+        // sling model with adaptable argument
+        arguments.put("adaptable", context.jakartaRequest());
+        outcome = provider.provide(SlingJakartaHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // sling model with adaptable argument of the wrong type
+        arguments.put("adaptable", Mockito.mock(Adaptable.class));
+        outcome = provider.provide(OtherModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+    }
+
+    @Test
+    public void testProvideForBundleHeaderDeclaredSlingModelWithoutBindingValues() {
+        // use a bindings that doesn't resolve anything
+        SlingBindings mockSlingBindings = Mockito.mock(SlingBindings.class);
+        Mockito.when(renderContext.getBindings()).thenReturn(mockSlingBindings);
+
+        simulateBundleStartedWithSlingModelClasses();
+
+        // sling model with javax servlet adaptable
+        ProviderOutcome outcome =
+                provider.provide(SlingHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+
+        // sling model with jakarta servlet adaptable
+        outcome = provider.provide(SlingJakartaHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+
+        // sling model with resource adaptable
+        outcome = provider.provide(ResourceModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+    }
+
+    @Test
+    public void testProvideForOsgiService() {
+        Mockito.when(mockBundledUnitManager.getServiceForBundledRenderUnit(
+                        any(Bindings.class), eq(SlingJakartaHttpServletRequestModel.class)))
+                .thenReturn(new SlingJakartaHttpServletRequestModel());
+
+        ProviderOutcome outcome =
+                provider.provide(SlingJakartaHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+    }
+
+    @Test
+    public void testProvideWithRelativeClassName() {
+        // null RenderUnit fails
+        ProviderOutcome outcome =
+                provider.provide(SlingJakartaHttpServletRequestModel.class.getSimpleName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+
+        // simulate non-null RenderUnit
+        RenderUnit mockRenderUnit = new MockRenderUnit();
+        Mockito.when(mockBundledUnitManager.getRenderUnit(requestBindings)).thenReturn(mockRenderUnit);
+        outcome = provider.provide(SlingJakartaHttpServletRequestModel.class.getSimpleName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+    }
+
+    @Test
+    public void testProvideForModelAdaptedFromAdaptable() {
+        registerTestModelAdapterManagers();
+
+        // sling model with javax servlet adaptable
+        ProviderOutcome outcome =
+                provider.provide(SlingHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // sling model with jakarta servlet adaptable
+        outcome = provider.provide(SlingJakartaHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // sling model with resource adaptable
+        outcome = provider.provide(ResourceModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // sling model with adaptable argument
+        arguments.put("adaptable", context.jakartaRequest());
+        outcome = provider.provide(SlingJakartaHttpServletRequestModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+    }
+
+    @Test
+    public void testProvideForPojo() {
+        // clear the field so we don't even consider that path
+        ReflectionTools.setFieldWithReflection(provider, "modelFactory", null);
+
+        // use a bindings that doesn't resolve anything
+        SlingBindings mockSlingBindings = Mockito.mock(SlingBindings.class);
+        Mockito.when(renderContext.getBindings()).thenReturn(mockSlingBindings);
+
+        // interface
+        ProviderOutcome outcome = provider.provide(InterfaceModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+        assertTrue(outcome.getCause() instanceof IllegalArgumentException);
+
+        // abstract class
+        outcome = provider.provide(AbstractModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isFailure());
+        assertTrue(outcome.getCause() instanceof IllegalArgumentException);
+
+        // enum
+        outcome = provider.provide(EnumModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // pojo
+        outcome = provider.provide(PojoModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // pojo that implements Use
+        outcome = provider.provide(PojoUseModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+    }
+
+    @Test
+    public void testProvideWithSlingHTLMasterCompiler() {
+        // to bypass the first code path
+        Mockito.when(mockBundledUnitManager.getBundledRenderUnitClassloader(any(Bindings.class)))
+                .thenReturn(null);
+
+        // simulate the SlingHTLMasterCompiler service
+        SlingHTLMasterCompiler mockSlingHTLMasterCompiler = Mockito.mock(SlingHTLMasterCompiler.class);
+        context.registerService(SlingHTLMasterCompiler.class, mockSlingHTLMasterCompiler);
+
+        // re-create to make sure the injected SlingHTLMasterCompiler field is set
+        provider = context.registerInjectActivateService(JavaUseProvider.class);
+        assertNotNull(provider);
+
+        // try non-Use resource backed path
+        Mockito.when(mockSlingHTLMasterCompiler.getResourceBackedUseObject(renderContext, PojoModel.class.getName()))
+                .thenReturn(new PojoModel());
+        ProviderOutcome outcome = provider.provide(PojoModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // try Use resource backed path
+        Mockito.when(mockSlingHTLMasterCompiler.getResourceBackedUseObject(renderContext, PojoUseModel.class.getName()))
+                .thenReturn(new PojoUseModel());
+        outcome = provider.provide(PojoUseModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // try classloader loaded path
+        Mockito.when(mockSlingHTLMasterCompiler.getResourceBackedUseObject(renderContext, PojoUseModel.class.getName()))
+                .thenReturn(null);
+        Mockito.when(mockSlingHTLMasterCompiler.getClassLoader())
+                .thenReturn(getClass().getClassLoader());
+        outcome = provider.provide(PojoUseModel.class.getName(), renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // try failing classloader loaded path
+        Mockito.when(mockSlingHTLMasterCompiler.getResourceBackedUseObject(renderContext, "package1.Invalid"))
+                .thenReturn(null);
+        outcome = provider.provide("package1.Invalid", renderContext, arguments);
+        assertTrue(outcome.isFailure());
+
+        // try no sling script helper path
+        SlingBindings mockSlingBindings = Mockito.mock(SlingBindings.class);
+        Mockito.when(renderContext.getBindings()).thenReturn(mockSlingBindings);
+        outcome = provider.provide("package1.Invalid", renderContext, arguments);
+        assertTrue(outcome.isFailure());
+    }
+
+    @SuppressWarnings("deprecation")
+    private void registerTestModelAdapterManagers() {
+        context.registerService(
+                AdapterFactory.class,
+                new TestModelsAdapterFactory(),
+                Map.of(
+                        AdapterFactory.ADAPTER_CLASSES,
+                        new String[] {SlingHttpServletRequestModel.class.getName()},
+                        AdapterFactory.ADAPTABLE_CLASSES,
+                        new String[] {org.apache.sling.api.SlingHttpServletRequest.class.getName()}));
+        context.registerService(
+                AdapterFactory.class,
+                new TestModelsAdapterFactory(),
+                Map.of(
+                        AdapterFactory.ADAPTER_CLASSES,
+                        new String[] {SlingJakartaHttpServletRequestModel.class.getName()},
+                        AdapterFactory.ADAPTABLE_CLASSES,
+                        new String[] {SlingJakartaHttpServletRequest.class.getName()}));
+        context.registerService(
+                AdapterFactory.class,
+                new TestModelsAdapterFactory(),
+                Map.of(
+                        AdapterFactory.ADAPTER_CLASSES,
+                        new String[] {ResourceModel.class.getName()},
+                        AdapterFactory.ADAPTABLE_CLASSES,
+                        new String[] {Resource.class.getName()}));
+    }
+
+    private void simulateBundleStartedWithSlingModelClasses() {
+        MockBundle mockBundle = (MockBundle) context.bundleContext().getBundle();
+        mockBundle.setHeaders(Map.of(
+                "Sling-Model-Classes",
+                String.join(
+                        ",",
+                        SlingHttpServletRequestModel.class.getName(),
+                        SlingJakartaHttpServletRequestModel.class.getName(),
+                        ResourceModel.class.getName(),
+                        OtherModel.class.getName(),
+                        ResourceModel2.class.getName())));
+        MockOsgi.sendBundleEvent(context.bundleContext(), new BundleEvent(BundleEvent.STARTED, mockBundle));
+    }
+
+    private static class TestModelsAdapterFactory implements AdapterFactory {
+        @Override
+        public <T> T getAdapter(final Object adaptable, final Class<T> type) {
+            try {
+                return type.getDeclaredConstructor().newInstance();
+            } catch (InstantiationException
+                    | IllegalAccessException
+                    | IllegalArgumentException
+                    | InvocationTargetException
+                    | NoSuchMethodException
+                    | SecurityException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ReflectionTools.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ReflectionTools.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Utilities to help test private fields
+ */
+public class ReflectionTools {
+
+    private ReflectionTools() {
+        // to hide public ctor
+    }
+
+    public static void setFieldWithReflection(Object obj, String fieldName, Object value) {
+        try {
+            Class<?> clazz = obj.getClass();
+            Field field = null;
+            do {
+                try { // NOSONAR
+                    field = clazz.getDeclaredField(fieldName);
+                } catch (NoSuchFieldException nsfe) {
+                    clazz = clazz.getSuperclass();
+                }
+            } while (field == null && clazz != null);
+            if (field != null) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    if (!field.canAccess(null)) {
+                        field.setAccessible(true);
+                    }
+                    field.set(null, value);
+                } else {
+                    if (!field.canAccess(obj)) {
+                        field.setAccessible(true);
+                    }
+                    field.set(obj, value);
+                }
+            } else {
+                fail("Failed to find field via reflection: " + fieldName);
+            }
+        } catch (IllegalArgumentException | IllegalAccessException | SecurityException e) {
+            fail("Failed to set field via reflection: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ResourceUseProviderTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/ResourceUseProviderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use;
+
+import java.util.Map;
+
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.scripting.sightly.render.RenderContext;
+import org.apache.sling.scripting.sightly.use.ProviderOutcome;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class ResourceUseProviderTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    private ResourceUseProvider provider;
+
+    private SlingBindings arguments;
+    private RenderContext renderContext;
+    private SlingBindings requestBindings;
+
+    @Before
+    public void setUp() throws PersistenceException {
+        provider = context.registerInjectActivateService(ResourceUseProvider.class);
+        assertNotNull(provider);
+
+        arguments = new SlingBindings();
+
+        ResourceResolver rr = context.resourceResolver();
+        Resource rootResource = rr.getResource("/");
+        Resource node1 = context.currentResource(rr.create(rootResource, "node1", Map.of()));
+        rr.create(node1, "child1", Map.of());
+        rr.create(rootResource, "node3", Map.of("jcr:primaryType", "sling:nonexisting"));
+
+        renderContext = Mockito.mock(RenderContext.class);
+        requestBindings = (SlingBindings) context.jakartaRequest().getAttribute(SlingBindings.class.getName());
+        assertNotNull(requestBindings);
+        Mockito.when(renderContext.getBindings()).thenReturn(requestBindings);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.engine.extension.use.ResourceUseProvider#provide(java.lang.String, org.apache.sling.scripting.sightly.render.RenderContext, javax.script.Bindings)}.
+     */
+    @Test
+    public void testProvide() {
+        // absolute path that exists
+        ProviderOutcome outcome = provider.provide("/node1", renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+
+        // absolute path that does not exists
+        outcome = provider.provide("/node2", renderContext, arguments);
+        assertTrue(outcome.isFailure());
+
+        // absolute path that does exists, but sling:nonexisting type
+        outcome = provider.provide("/node3", renderContext, arguments);
+        assertTrue(outcome.isFailure());
+
+        // relative path that exists
+        outcome = provider.provide("child1", renderContext, arguments);
+        assertTrue(outcome.isSuccess());
+    }
+
+    @Test
+    public void testProvideWithCaughtException() {
+        requestBindings = Mockito.spy(requestBindings);
+        Mockito.when(renderContext.getBindings()).thenReturn(requestBindings);
+        SlingJakartaHttpServletRequest mockJakartaRequest = Mockito.spy(context.jakartaRequest());
+        Mockito.when(requestBindings.get(SlingBindings.JAKARTA_REQUEST)).thenReturn(mockJakartaRequest);
+        Mockito.when(mockJakartaRequest.getResourceResolver()).thenThrow(IllegalStateException.class);
+
+        ProviderOutcome outcome = provider.provide("/node1", renderContext, arguments);
+        assertTrue(outcome.isFailure());
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/AbstractModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/AbstractModel.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+public abstract class AbstractModel {}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/EnumModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/EnumModel.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+public enum EnumModel {
+    ONE
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/InterfaceModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/InterfaceModel.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+/**
+ *
+ */
+public interface InterfaceModel {}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/MockRenderUnit.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/MockRenderUnit.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+import javax.script.Bindings;
+
+import java.io.PrintWriter;
+
+import org.apache.sling.scripting.sightly.render.RenderContext;
+import org.apache.sling.scripting.sightly.render.RenderUnit;
+
+/**
+ *
+ */
+public class MockRenderUnit extends RenderUnit {
+
+    @Override
+    protected void render(PrintWriter out, Bindings bindings, Bindings arguments, RenderContext renderContext) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/OtherModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/OtherModel.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = ResourceModel.class)
+public class OtherModel {}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/PojoModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/PojoModel.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+public class PojoModel {}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/PojoUseModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/PojoUseModel.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+import javax.script.Bindings;
+
+import org.apache.sling.scripting.sightly.pojo.Use;
+
+public class PojoUseModel implements Use {
+
+    @Override
+    public void init(Bindings bindings) {
+        // for testing
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/ResourceModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/ResourceModel.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = Resource.class)
+public class ResourceModel {}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/ResourceModel2.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/ResourceModel2.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = Resource.class)
+public class ResourceModel2 {
+
+    public ResourceModel2() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/SlingHttpServletRequestModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/SlingHttpServletRequestModel.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+import org.apache.sling.models.annotations.Model;
+
+@SuppressWarnings("deprecation")
+@Model(adaptables = org.apache.sling.api.SlingHttpServletRequest.class)
+public class SlingHttpServletRequestModel {}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/SlingJakartaHttpServletRequestModel.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/extension/use/testmodels/SlingJakartaHttpServletRequestModel.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.engine.extension.use.testmodels;
+
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.models.annotations.Model;
+
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
+public class SlingJakartaHttpServletRequestModel {}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/engine/runtime/SlingRuntimeObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/engine/runtime/SlingRuntimeObjectModelTest.java
@@ -91,13 +91,15 @@ public class SlingRuntimeObjectModelTest {
         assertTrue(runtimeObjectModel.toBoolean("TrUE"));
         Integer[] testArray = new Integer[] {1, 2, 3};
         int[] testPrimitiveArray = new int[] {1, 2, 3};
-        List testList = Arrays.asList(testArray);
+        List<Integer> testList = Arrays.asList(testArray);
         assertTrue(runtimeObjectModel.toBoolean(testArray));
         assertTrue(runtimeObjectModel.toBoolean(testPrimitiveArray));
         assertFalse(runtimeObjectModel.toBoolean(new Integer[] {}));
         assertTrue(runtimeObjectModel.toBoolean(testList));
         assertFalse(runtimeObjectModel.toBoolean(Collections.emptyList()));
         Map<String, Integer> map = new HashMap<String, Integer>() {
+            private static final long serialVersionUID = 1L;
+
             {
                 put("one", 1);
                 put("two", 2);
@@ -120,6 +122,8 @@ public class SlingRuntimeObjectModelTest {
         assertTrue(runtimeObjectModel.toBoolean(Optional.of(1)));
         assertTrue(runtimeObjectModel.toBoolean(new Object()));
         Map<String, String> map2 = new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public String toString() {
                 return null;
@@ -148,13 +152,15 @@ public class SlingRuntimeObjectModelTest {
         assertTrue(runtimeObjectModel.toBoolean("TrUE"));
         Integer[] testArray = new Integer[] {1, 2, 3};
         int[] testPrimitiveArray = new int[] {1, 2, 3};
-        List testList = Arrays.asList(testArray);
+        List<Integer> testList = Arrays.asList(testArray);
         assertTrue(runtimeObjectModel.toBoolean(testArray));
         assertTrue(runtimeObjectModel.toBoolean(testPrimitiveArray));
         assertFalse(runtimeObjectModel.toBoolean(new Integer[] {}));
         assertTrue(runtimeObjectModel.toBoolean(testList));
         assertFalse(runtimeObjectModel.toBoolean(Collections.emptyList()));
         Map<String, Integer> map = new HashMap<String, Integer>() {
+            private static final long serialVersionUID = 1L;
+
             {
                 put("one", 1);
                 put("two", 2);
@@ -177,6 +183,8 @@ public class SlingRuntimeObjectModelTest {
         assertTrue(runtimeObjectModel.toBoolean(Optional.of(1)));
         assertTrue(runtimeObjectModel.toBoolean(new Object()));
         Map<String, String> map2 = new HashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public String toString() {
                 return null;
@@ -191,12 +199,15 @@ public class SlingRuntimeObjectModelTest {
 
         ValueMap getValueMap() {
             return new ValueMapDecorator(new HashMap<String, Object>() {
+                private static final long serialVersionUID = 1L;
+
                 {
                     put("test", VALUE_MAP_VALUE);
                 }
             });
         }
 
+        @SuppressWarnings("unchecked")
         @Nullable
         @Override
         public <AdapterType> AdapterType adaptTo(@NotNull Class<AdapterType> aClass) {

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/utils/BindingsUtilsTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/utils/BindingsUtilsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.scripting.sightly.impl.utils;
+
+import javax.script.Bindings;
+
+import java.util.Map;
+
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.scripting.LazyBindings;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ *
+ */
+public class BindingsUtilsTest {
+
+    @Rule
+    public SlingContext context = new SlingContext();
+
+    private SlingBindings slingBindings;
+
+    @Before
+    public void setUp() {
+        slingBindings = (SlingBindings) context.jakartaRequest().getAttribute(SlingBindings.class.getName());
+        assertNotNull(slingBindings);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.utils.BindingsUtils#getResource(javax.script.Bindings)}.
+     */
+    @Test
+    public void testGetResource() throws PersistenceException {
+        ResourceResolver rr = context.resourceResolver();
+        context.currentResource(rr.create(rr.getResource("/"), "node1", Map.of()));
+        assertNotNull(BindingsUtils.getResource(slingBindings));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.utils.BindingsUtils#getRequest(javax.script.Bindings)}.
+     * @deprecated use {@link #testGetJakartaRequest()} instead
+     */
+    @Deprecated(since = "2.0.0-1.4.0")
+    @Test
+    public void testGetRequest() {
+        assertNotNull(BindingsUtils.getRequest(slingBindings));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.utils.BindingsUtils#getResponse(javax.script.Bindings)}.
+     * @deprecated use {@link #testGetJakartaResponse()} instead
+     */
+    @Deprecated(since = "2.0.0-1.4.0")
+    @Test
+    public void testGetResponse() {
+        assertNotNull(BindingsUtils.getResponse(slingBindings));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.utils.BindingsUtils#getJakartaRequest(javax.script.Bindings)}.
+     */
+    @Test
+    public void testGetJakartaRequest() {
+        assertNotNull(BindingsUtils.getJakartaRequest(slingBindings));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.utils.BindingsUtils#getJakartaResponse(javax.script.Bindings)}.
+     */
+    @Test
+    public void testGetJakartaResponse() {
+        assertNotNull(BindingsUtils.getJakartaResponse(slingBindings));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.utils.BindingsUtils#getHelper(javax.script.Bindings)}.
+     */
+    @Test
+    public void testGetHelper() {
+        assertNotNull(BindingsUtils.getHelper(slingBindings));
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.scripting.sightly.impl.utils.BindingsUtils#merge(javax.script.Bindings, javax.script.Bindings)}.
+     */
+    @Test
+    public void testMerge() {
+        LazyBindings otherBindings = new LazyBindings();
+        otherBindings.put("key1", "value1");
+        Bindings merged = BindingsUtils.merge(slingBindings, otherBindings);
+        assertEquals("value1", merged.get("key1"));
+    }
+}

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverConcurrentTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverConcurrentTest.java
@@ -80,7 +80,7 @@ public class ScriptDependencyResolverConcurrentTest {
         testResourceProperties.put("sling:resourceType", "inherit");
         ResourceUtil.getOrCreateResource(
                 context.resourceResolver(), "/content/test", testResourceProperties, "sling:Folder", true);
-        context.request().setResource(context.resourceResolver().getResource("/content/test"));
+        context.jakartaRequest().setResource(context.resourceResolver().getResource("/content/test"));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class ScriptDependencyResolverConcurrentTest {
         RenderContext renderContext = mock(RenderContext.class);
         Bindings bindings = mock(Bindings.class);
         when(renderContext.getBindings()).thenReturn(bindings);
-        when(bindings.get(SlingBindings.REQUEST)).thenReturn(context.request());
+        when(bindings.get(SlingBindings.JAKARTA_REQUEST)).thenReturn(context.jakartaRequest());
 
         // invoke resolveScript with the same identifier
         int size = 100;

--- a/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/impl/utils/ScriptDependencyResolverTest.java
@@ -77,12 +77,12 @@ public class ScriptDependencyResolverTest {
         testResourceProperties.put("sling:resourceType", "inherit");
         ResourceUtil.getOrCreateResource(
                 context.resourceResolver(), "/content/test", testResourceProperties, "sling:Folder", true);
-        context.request().setResource(context.resourceResolver().getResource("/content/test"));
+        context.jakartaRequest().setResource(context.resourceResolver().getResource("/content/test"));
 
         renderContext = mock(RenderContext.class);
         Bindings bindings = mock(Bindings.class);
         when(renderContext.getBindings()).thenReturn(bindings);
-        when(bindings.get(SlingBindings.REQUEST)).thenReturn(context.request());
+        when(bindings.get(SlingBindings.JAKARTA_REQUEST)).thenReturn(context.jakartaRequest());
     }
 
     // Perform the remaining setup work, which depends on the configuration


### PR DESCRIPTION
bump bundle major version to 2.0.0-1.4.0
bump minimum java version to 17

bump slf4j-api to the 2.x version
bump sling api to 3.x
bump models.api to 2.0.0-SNAPSHOT (see [SLING-12874](https://issues.apache.org/jira/browse/SLING-12874))
bump org.apache.sling.i18n to 3.0.0-SNAPSHOT (see [SLING-12312](https://issues.apache.org/jira/browse/SLING-12312))

bump org.apache.sling.testing.sling-mock.junit4 to 4.0.0-SNAPSHOT (see [SLING-12880](https://issues.apache.org/jira/browse/SLING-12880))

migrate the javax.servlet references in non-pubic classes to jakarta.servlet
deprecate all the remaining classes that touch javax.*
add additional tests to improve code coverage
resolve various sonar warnings